### PR TITLE
Added 'bigquery' enpoint + other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 
 # Microservice responsible for proxying requests to Solr
 
+To request bigquery data:
+
+```python
+requests.post('http://localhost:5000/bigquery', params={'q':'*:*', 'wt':'json', 'fl':'bibcode', 'fq': '{!bitset}'}, data='bibcode\n1907AN....174...59.\n1908PA.....16..445.\n1989LNP...334..242S')
+```
+

--- a/solr/config.py
+++ b/solr/config.py
@@ -1,6 +1,10 @@
 APP_SECRET_KEY = 'fake'
+VERSION = 'v4.10' # Arbitrary string identifying solr (will be returned in the headers)
 
-SOLR_TVRH_HANDLER = 'http://localhost:8983/solr/tvrh'
-SOLR_SEARCH_HANDLER = 'http://localhost:8983/solr/select'
-SOLR_QTREE_HANDLER = 'http://locahost:8983/solr/qtree'
+SOLR_URL = 'http://localhost:8983/solr'
+
+SOLR_TVRH_HANDLER = SOLR_URL + '/tvrh'
+SOLR_SEARCH_HANDLER = SOLR_URL + '/select'
+SOLR_QTREE_HANDLER = SOLR_URL + '/qtree'
+SOLR_BIGQUERY_HANDLER = SOLR_URL + '/bigquery'
 

--- a/solr/tests/unittests/testSolr.py
+++ b/solr/tests/unittests/testSolr.py
@@ -1,5 +1,6 @@
 import sys, os
-PROJECT_HOME = os.path.abspath(os.path.join(os.path.dirname(__file__),'../../'))
+from urllib import urlencode
+PROJECT_HOME = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../'))
 sys.path.append(PROJECT_HOME)
 from flask.ext.testing import TestCase
 from flask import url_for, request
@@ -7,94 +8,158 @@ import unittest
 import json
 import httpretty
 import app
+import cgi
+from StringIO import StringIO
 
 class TestWebservices(TestCase):
   '''Tests that each route is an http response'''
   
-  def tearDown(self):
-    httpretty.disable()
-    httpretty.reset()
-
-  def setUp(self):
-    def request_callback(request, uri, headers):
-      headers.update({"content-type":"application/json"})
-      if request.method=='GET':
-        fl = request.querystring['fl']
-      elif request.method=='POST':
-        fl = request.parsed_body['fl']
-      if 'body' in fl:
-        return (400, headers, "{'The query was not sanitized properly'}")
-      else:
-        return (200, headers, '''{
-          "responseHeader(search)":{
-          "status":0, "QTime":0,
-          "params":{ "fl":"title,bibcode", "indent":"true", "wt":"json", "q":"*:*"}},
-          "response":{"numFound":10456930,"start":0,"docs":[
-            { "bibcode":"2005JGRC..110.4002G" },
-            { "bibcode":"2005JGRC..110.4003N" },
-            { "bibcode":"2005JGRC..110.4004Y" }]}}''')
-
-    httpretty.enable()
-    for method in [httpretty.GET,httpretty.POST]:
-      httpretty.register_uri(
-        method, 
-        self.app.config.get('SOLR_SEARCH_HANDLER'),
-        body=request_callback
-      )
-      httpretty.register_uri(
-        method, 
-        self.app.config.get('SOLR_QTREE_HANDLER'),
-        content_type='application/json',
-        status=200,
-        body="""{"foo": "bar"}"""
-      )
-      httpretty.register_uri(
-        method, 
-        self.app.config.get('SOLR_TVRH_HANDLER'),
-        content_type='application/json',
-        status=200,
-        body="""{"responseHeader(tvrh)":{"status":0,"QTime":179},"response":{"numFound":0,"start":0,"docs":[]}}"""
-      )
 
   def create_app(self):
     '''Start the wsgi application'''
     _app = app.create_app()
     return _app
 
+  @httpretty.activate
   def test_sanitization(self):
-    r = self.client.get(
-      url_for('solr.search'),
-      data={'q': 'star', 'fl': 'body,title'}
-    )
-    self.assertStatus(r, 200)
-    self.assertIn('responseHeader(search)',json.loads(r.data))
-      
+    def request_callback(request, uri, headers):
+        if 'fl' not in request.parsed_body:
+            return (500, headers, "{'The query parameters were not passed properly'}")
+            if 'title' not in request.parsed_body['fl']:
+                return (500, headers, "{'The query parameters were not passed properly'}")
+        if 'body' in request.parsed_body['fl']:
+            return (500, headers, "{'The query was not sanitized properly'}")
+        return (200, headers, "{\"msg\": \"The %s response from %s\"}" % (request.method, uri))
+
+    httpretty.register_uri(
+        httpretty.POST, self.app.config.get('SOLR_SEARCH_HANDLER'),
+        body=request_callback)
+    
+    resp = self.client.get(url_for('solr.search'),
+                data={'q': 'star', 'fl': 'body,title'})
+    self.assertEqual(resp.status_code, 200)
+
+
+  @httpretty.activate
   def test_search(self):
+    httpretty.register_uri(
+            httpretty.POST, self.app.config.get('SOLR_SEARCH_HANDLER'),
+            content_type='application/json',
+            status=200,
+            body="""{
+            "responseHeader":{
+            "status":0, "QTime":0,
+            "params":{ "fl":"title,bibcode", "indent":"true", "wt":"json", "q":"*:*"}},
+            "response":{"numFound":10456930,"start":0,"docs":[
+              { "bibcode":"2005JGRC..110.4002G" },
+              { "bibcode":"2005JGRC..110.4003N" },
+              { "bibcode":"2005JGRC..110.4004Y" }]}}""")
+
     r = self.client.get(url_for('solr.search'))
     self.assertStatus(r, 200)
-    self.assertIn('responseHeader(search)',json.loads(r.data))
-
-    r = self.client.post(url_for('solr.search'))
-    self.assertStatus(r, 200)
-    self.assertIn('responseHeader(search)',json.loads(r.data))
-
+    self.assertIn('responseHeader', r.json)
+        
+    
+  @httpretty.activate
   def test_qtree(self):
+    httpretty.register_uri(
+            httpretty.POST, self.app.config.get('SOLR_QTREE_HANDLER'),
+            content_type='application/json',
+            status=200,
+            body=r'''{
+             "qtree": "\n{\"name\":\"OPERATOR\", \"label\":\"DEFOP\", \"children\": [\n    {\"name\":\"MODIFIER\", \"label\":\"MODIFIER\", \"children\": [\n        {\"name\":\"TMODIFIER\", \"label\":\"TMODIFIER\", \"children\": [\n            {\"name\":\"FIELD\", \"label\":\"FIELD\", \"children\": [\n                {\"name\":\"QNORMAL\", \"label\":\"QNORMAL\", \"children\": [\n                    {\"name\":\"TERM_NORMAL\", \"input\":\"star\", \"start\":0, \"end\":3}]\n                }]\n            }]\n        }]\n    }]\n}",
+             "responseHeader": {
+              "status": 0,
+              "QTime": 6,
+              "params": {
+               "q": "star",
+               "wt": "json",
+               "fl": "id"
+              }
+             }
+            }'''
+            )
+
     r = self.client.get(url_for('solr.qtree'))
-    self.assertStatus(r, 200)
-    self.assertIn('foo',json.loads(r.data))
-
-    r = self.client.post(url_for('solr.qtree'))
-    self.assertStatus(r, 200)
-    self.assertIn('foo',json.loads(r.data))
-      
-  def test_tvrh(self):
-    r = self.client.get(url_for('solr.tvrh'))
-    self.assertStatus(r, 200)
-    self.assertIn('responseHeader(tvrh)',json.loads(r.data))
-
+    self.assertEqual(r.status_code, 200)
+    self.assertIn('qtree', r.json)
+    self.assertIn('name', json.loads(r.json['qtree']))
+    
     r = self.client.post(url_for('solr.tvrh'))
-    self.assertStatus(r, 200)
-    self.assertIn('responseHeader(tvrh)',json.loads(r.data))
+    self.assertStatus(r, 405)
+
+      
+  @httpretty.activate
+  def test_tvrh(self):
+    httpretty.register_uri(
+            httpretty.POST, self.app.config.get('SOLR_TVRH_HANDLER'),
+            content_type='application/json',
+            status=200,
+            body="""
+            {
+  "responseHeader":{
+    "status":0,
+    "QTime":1,
+    "params":{
+      "fl":"title",
+      "indent":"on",
+      "start":"0",
+      "q":"*:*",
+      "tv":"true",
+      "tv.all":"true",
+      "tv.fl":"abstract",
+      "wt":"json",
+      "qt":"tvrh",
+      "rows":"1"}},
+  "response":{"numFound":10715572,"start":0,"docs":[
+      {
+        "title":["The Structure of Convection in the Planetary Boundary -"]}]
+  },
+  "termVectors":[
+    "uniqueKeyFieldName","id",
+    "374878",[
+      "uniqueKey","374878"]]}
+            """)
+
+    resp = self.client.get(url_for('solr.tvrh'))
+    self.assertEqual(resp.status_code, 200)
+    self.assertIn('termVectors', resp.json)
+    
+  @httpretty.activate
+  def test_bigquery(self):
+    def request_callback(request, uri, headers):
+        #form = cgi.FieldStorage(fp=request.rfile, headers=request.headers, environ=request.environ)
+        if 'q' not in request.querystring:
+            return (500, headers, "{'The query parameters were not passed properly'}")
+        return (200, headers, "{\"msg\": \"The %s response from %s\"}" % (request.method, uri))
+
+    httpretty.register_uri(
+        httpretty.POST, self.app.config.get('SOLR_BIGQUERY_HANDLER'),
+        body=request_callback)
+
+    # this will work in real-life solr
+    # r = requests.post('http://54.173.87.140:8983/solr/bigquery', params={'q':'*:*', 'wt':'json', 'fl':'bibcode', 'fq': '{!bitset}'}, headers={'content-type': 'big-query/csv'}, data=bibcodes); print r.text
+
+    #requests.post('http://localhost:8983/solr/bigquery', params={'q':'*:*', 'wt':'json', 'fl':'bibcode'}, headers={'content-type': 'big-query/csv'}, data=bibcodes)
+    bibcodes = 'bibcode\n1907AN....174...59.\n1908PA.....16..445.\n1989LNP...334..242S'
+    resp = self.client.post(
+            url_for('solr.bigquery'), 
+            content_type='multipart/form-data', 
+            data={'q' : '*:*',
+                 'fl' : 'bibcode',
+                 'fq' : '{!bitset}',
+                 'file_field' : (StringIO(bibcodes), 'big-query/csv')})
+    
+    self.assertEqual(resp.status_code, 200)   
+    
+    resp = self.client.post(
+            url_for('solr.bigquery'), 
+            content_type='multipart/form-data', 
+            data={'q' : '*:*',
+                 'fl' : 'bibcode',
+                 'file_field' : (StringIO(bibcodes), 'big-query/csv')})
+    
+    self.assertEqual(resp.status_code, 403)
 
 if __name__ == '__main__':
   unittest.main()

--- a/solr/views.py
+++ b/solr/views.py
@@ -85,6 +85,7 @@ class Qtree(SolrInterface):
   handler = 'SOLR_QTREE_HANDLER'
   
 class BigQuery(Resource):
+    '''Exposes the bigquery endpoint'''
     scopes = ['ads:bigquery']
     rate_limit = [100, 60*60*24]
     handler = 'SOLR_BIGQUERY_HANDLER'

--- a/solr/views.py
+++ b/solr/views.py
@@ -5,6 +5,7 @@ import sys
 from urllib import urlencode
 import urlparse
 from client import Client
+import json
 
 client = Client(None,send_oauth2_token=False)
 
@@ -39,15 +40,15 @@ class SolrInterface(Resource):
 
   def get(self):
     query = SolrInterface.cleanup_solr_request(dict(request.args))
-    r = client.session.get(current_app.config[self.handler],
-      params=urlencode(query, doseq=True))
-    return r.json()
+    headers = dict(request.headers)
+    headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    r = client.session.post(
+        current_app.config[self.handler],
+        data=query,
+        headers=headers
+        )
+    return r.text, r.status_code, r.headers
 
-  def post(self):
-    query = SolrInterface.cleanup_solr_request(urlparse.parse_qs(request.data))
-    r = client.session.post(current_app.config[self.handler], 
-      data=urlencode(query, doseq=True))
-    return r.json()
 
   @staticmethod
   def cleanup_solr_request(payload,disallowed=['body','full']):
@@ -82,3 +83,38 @@ class Qtree(SolrInterface):
   scopes = ['ads:default']
   rate_limit = [100,60*60*24]
   handler = 'SOLR_QTREE_HANDLER'
+  
+class BigQuery(Resource):
+    scopes = ['ads:bigquery']
+    rate_limit = [100, 60*60*24]
+    handler = 'SOLR_BIGQUERY_HANDLER'
+    
+    def post(self):
+        payload = dict(request.form)
+        payload.update(request.args)
+        headers = dict(request.headers)
+        
+        query = SolrInterface.cleanup_solr_request(payload)
+        if 'fq' not in query or len(filter(lambda x: '!bitset' in x, query['fq'])) == 0:
+            return json.dumps({'error': "Missing fq={!bitset}"}), 403
+
+        if 'Content-Type' in headers and not 'big-query' in headers['Content-Type']:
+            headers['Content-Type'] = 'big-query/csv'
+                        
+        if request.data:
+            # r = requests.post('http://localhost:5000/bigquery', params={'q':'*:*', 'wt':'json', 'fl':'bibcode', 'fq': '{!bitset}'}, headers={'content-type': 'big-query/csv'}, data=bibcodes); print r.text
+            r = client.session.post(current_app.config[self.handler],
+              params = query, 
+              data=request.data,
+              headers=headers,
+            )
+        elif request.files:
+            # requests.post('http://localhost:5000/bigquery', data={'q':'*:*', 'wt':'json', 'fl':'bibcode', 'fq': '{!bitset}'}, files={'file': (StringIO('bibcode\n1907AN....174...59.\n1908PA.....16..445.\n1989LNP...334..242S'), 'big-query/csv')})
+            r = client.session.post(current_app.config[self.handler], 
+              params=query,
+              headers=headers,
+              files=request.files
+              )
+        else:
+            return json.dumps({'error': "Wrong request"}), 403
+        return r.text, r.status_code, r.headers


### PR DESCRIPTION
- /bigquery now exposes /solr/bigquery handler
- updated tests
- fixed bugs (ie. query parameters were not tested)
- made each test independent (to show different data)
- forced difference in GET/POST
- updated config (typo) + added VERSION
- removed POST methods from query methods
- made handlers return response.text (instead of parsing
  and re-parsing json, this was trivial, and it might have
  positive effect on execution: especially when solr returns
  lots of data)