### PR TITLE
Issue #4: added functionality to check the form

### DIFF
--- a/solr/tests/unittests/testSolr.py
+++ b/solr/tests/unittests/testSolr.py
@@ -225,5 +225,17 @@ class TestWebservices(TestCase):
 
         self.assertEqual(resp.status_code, 400)
 
+        resp = self.client.post(
+                url_for('bigquery'),
+                data={
+                    'q': '*:*',
+                    'fl': 'bibcode',
+                    'fq': '{!bitset}',
+                    'bibcode': bibcodes,
+                    }
+        )
+
+        self.assertEqual(resp.status_code, 200)
+
 if __name__ == '__main__':
     unittest.main()

--- a/solr/views.py
+++ b/solr/views.py
@@ -103,7 +103,7 @@ class BigQuery(Resource):
         payload = dict(request.form)
         payload.update(request.args)
         headers = dict(request.headers)
-        
+
         query = SolrInterface.cleanup_solr_request(payload)
         if 'fq' not in query or \
                 len(filter(lambda x: '!bitset' in x, query['fq'])) == 0:
@@ -111,12 +111,13 @@ class BigQuery(Resource):
 
         if 'big-query' not in headers.get('Content-Type', ''):
             headers['Content-Type'] = 'big-query/csv'
-                        
-        if request.data:
+
+        if query.get('bibcode'):
+            bibcodes = ''.join(query.pop('bibcode'))
             r = requests.post(
                 current_app.config[self.handler],
                 params=query,
-                data=request.data,
+                data=bibcodes,
                 headers=headers,
                 cookies=SolrInterface.set_cookies(request),
             )


### PR DESCRIPTION
Added functionality to look for the bibcodes inside the form rather than the request data.
The rest of the logic follows as normal.

A test has been included to test this form of functionality.

@vsudilov or @romanchyla; see any issues/dislikes with the fix before I try it?