### PR TITLE
Issue #4 adding default bitset parameter and ensuring only a single stream

### DIFF
--- a/solr/tests/unittests/testSolr.py
+++ b/solr/tests/unittests/testSolr.py
@@ -8,6 +8,7 @@ import httpretty
 import json
 import app
 from werkzeug.security import gen_salt
+from werkzeug.datastructures import MultiDict
 from StringIO import StringIO
 
 class TestWebservices(TestCase):
@@ -213,6 +214,7 @@ class TestWebservices(TestCase):
 
         self.assertEqual(resp.status_code, 200)
 
+        # Missing 'fq' parameter
         resp = self.client.post(
                 url_for('bigquery'),
                 content_type='multipart/form-data',
@@ -223,7 +225,43 @@ class TestWebservices(TestCase):
                     }
         )
 
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue('bitset' in resp.data)
+
+        # 'fq' without bitset
+        resp = self.client.post(
+                url_for('bigquery'),
+                content_type='multipart/form-data',
+                data={
+                    'q': '*:*',
+                    'fl': 'bibcode',
+                    'fq': '{compression = true}',
+                    'file_field': (StringIO(bibcodes), 'big-query/csv'),
+                    }
+        )
+        
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue('compression' in resp.data)
+        self.assertTrue('bitset' in resp.data)
+
+        # We only allow one content stream to be sent
+        data = MultiDict([
+            ('q', '*:*'),
+            ('fl', 'bibcode'),
+            ('fq', '{!bitset}'),
+            ('file_field', (StringIO(bibcodes), 'big-query/csv')),
+            ('file_field', (StringIO(bibcodes), 'big-query/csv')),
+        ])
+
+        resp = self.client.post(
+                url_for('bigquery'),
+                content_type='multipart/form-data',
+                data=data
+        )
+
         self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json['error'],
+                         'You can only pass one content stream.')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Should be in keeping with the [Zen of Python](http://legacy.python.org/dev/peps/pep-0020/) and JavaScript, which I was desecrating in my previous examples ;-).