### PR TITLE
ads/issue#57

### DIFF
--- a/solr/tests/unittests/test_solr.py
+++ b/solr/tests/unittests/test_solr.py
@@ -25,9 +25,20 @@ class TestSolrInterface(TestCase):
         """
         Simple test of the cleanup classmethod
         """
-        payload = {'fl': ['*,bibcode,title']}
+        payload = {'fl': ['id,bibcode,title,volume']}
         cleaned = SolrInterface.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['fl'], 'id,bibcode,title,volume')
 
+        payload = {'fl': ['id ', ' bibcode ', 'title ', ' volume']}
+        cleaned = SolrInterface.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['fl'], 'id,bibcode,title,volume')
+
+        payload = {'fl': ['id', 'bibcode', '*']}
+        cleaned = SolrInterface.cleanup_solr_request(payload)
+        self.assertNotIn('*', cleaned['fl'])
+
+        payload = {'fl': ['id,bibcode,*']}
+        cleaned = SolrInterface.cleanup_solr_request(payload)
         self.assertNotIn('*', cleaned['fl'])
 
 

--- a/solr/views.py
+++ b/solr/views.py
@@ -62,7 +62,10 @@ class SolrInterface(Resource):
         if 'fl' not in payload:
             payload['fl'] = 'id'
         else:
-            fields = [x.strip() for x in payload['fl'][0].split(',')]
+            fields = []
+            for y in payload['fl']:
+                fields.extend([i.strip() for i in y.split(',')])
+
             disallowed = current_app.config.get(
                 'SOLR_SERVICE_DISALLOWED_FIELDS'
             )
@@ -73,7 +76,7 @@ class SolrInterface(Resource):
             if '*' in fields:
                 fields = current_app.config.get('SOLR_SERVICE_ALLOWED_FIELDS')
             payload['fl'] = ','.join(fields)
-        
+
         max_hl = current_app.config.get('SOLR_SERVICE_MAX_SNIPPETS', 4)
         max_frag = current_app.config.get('SOLR_SERVICE_MAX_FRAGSIZE', 100)
         for k,v in payload.items():


### PR DESCRIPTION
The field parameter was never correctly checking any of the fields
other than the first value in the case that someone had passed an
array of field parameters, rather than comma separated.