### PR TITLE
Correctly build solr request parameters avoiding lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *pyc
 .idea
+python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: python
+
 python:
   - "2.7"
+
 install:
-  - pip install --upgrade pip
-  - pip install -r requirements.txt
-  - pip install -r dev-requirements.txt
+  - "pip install -r requirements.txt"
+  - "pip install -r dev-requirements.txt"
+
 script:
-  - py.test
+  - "py.test"
+
 after_success:
   - "coveralls"
+
+notifications:
+  email: false
+
 sudo: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/adsabs/ADSMicroserviceUtils.git@master
+git+https://github.com/adsabs/ADSMicroserviceUtils.git@v1.0.3
 Werkzeug==0.10.4
 Flask==0.10.1
 Flask-RESTful==0.3.5
@@ -7,5 +7,5 @@ flask-discoverer==0.0.2
 flask-consulate==0.1.2
 Flask-SQLAlchemy==2.1
 SQLAlchemy-Utils==0.27.7
-psycopg2==2.6.1
+psycopg2==2.7.3.2
 alembic==0.8.1

--- a/solr/tests/unittests/test_solr.py
+++ b/solr/tests/unittests/test_solr.py
@@ -41,6 +41,24 @@ class TestSolrInterface(TestCase):
         Simple test of the cleanup classmethod
         """
         si = SolrInterface()
+        payload = {}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
+        self.assertEqual(cleaned['fl'], 'id')
+
+        payload = {'rows': 1000000}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
+
+        payload = {'hl.snippets': 1000000, 'hl.fragsize': 1000000}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['hl.snippets'], self.app.config.get('SOLR_SERVICE_MAX_SNIPPETS', 4))
+        self.assertEqual(cleaned['hl.fragsize'], self.app.config.get('SOLR_SERVICE_MAX_FRAGSIZE', 100))
+
+        payload = {'fl': 'id,bibcode,title,volume'}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['fl'], 'id,bibcode,title,volume')
+
         payload = {'fl': ['id,bibcode,title,volume']}
         cleaned = si.cleanup_solr_request(payload)
         self.assertEqual(cleaned['fl'], 'id,bibcode,title,volume')
@@ -48,6 +66,7 @@ class TestSolrInterface(TestCase):
         payload = {'fl': ['id ', ' bibcode ', 'title ', ' volume']}
         cleaned = si.cleanup_solr_request(payload)
         self.assertEqual(cleaned['fl'], 'id,bibcode,title,volume')
+        self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
 
         payload = {'fl': ['id', 'bibcode', '*']}
         cleaned = si.cleanup_solr_request(payload)

--- a/solr/tests/unittests/test_solr.py
+++ b/solr/tests/unittests/test_solr.py
@@ -84,6 +84,10 @@ class TestSolrInterface(TestCase):
         cleaned = si.cleanup_solr_request(payload)
         self.assertNotIn('*', cleaned['fl'])
 
+        payload = {'fq': 'pos(1,author:foo)'}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['fq'], ['pos(1,author:foo)'])
+
 
     def test_limits(self):
         """

--- a/solr/tests/unittests/test_solr.py
+++ b/solr/tests/unittests/test_solr.py
@@ -46,9 +46,17 @@ class TestSolrInterface(TestCase):
         self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
         self.assertEqual(cleaned['fl'], 'id')
 
+        payload = {'rows': '1000000'}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
+
         payload = {'rows': 1000000}
         cleaned = si.cleanup_solr_request(payload)
         self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
+
+        payload = {'rows': '5,1000000'}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], 5)
 
         payload = {'hl.snippets': 1000000, 'hl.fragsize': 1000000}
         cleaned = si.cleanup_solr_request(payload)

--- a/solr/views.py
+++ b/solr/views.py
@@ -93,8 +93,9 @@ class SolrInterface(Resource):
                 payload[key] = ",".join(value)
 
         # Do not bypass the max rows limit
-        if ('rows' in payload and safe_int(payload['rows'], default=max_rows) > max_rows) \
-                or ('rows' not in payload):
+        if 'rows' in payload:
+            payload['rows'] = safe_int(payload['rows'].split(",")[0], default=max_rows) # In case of multiple rows params, select the first one
+        if 'rows' not in payload or  payload['rows'] > max_rows:
             payload['rows'] = max_rows
 
         # we disallow 'return everything'

--- a/solr/views.py
+++ b/solr/views.py
@@ -93,7 +93,7 @@ class SolrInterface(Resource):
                 payload[key] = ",".join(value)
 
         # Do not bypass the max rows limit
-        if 'rows' in payload:
+        if 'rows' in payload and isinstance(payload['rows'], basestring):
             payload['rows'] = safe_int(payload['rows'].split(",")[0], default=max_rows) # In case of multiple rows params, select the first one
         if 'rows' not in payload or  payload['rows'] > max_rows:
             payload['rows'] = max_rows

--- a/solr/views.py
+++ b/solr/views.py
@@ -178,7 +178,7 @@ class BigQuery(SolrInterface):
 
         if 'fq' not in query:
             query['fq'] = '{!bitset}'
-        elif '{!bitset}' not in query['fq']:
+        elif '!bitset' not in query['fq']:
             query['fq'] = ",".join(query['fq'].split(",") + [u'{!bitset}'])
 
         if 'big-query' not in headers.get('Content-Type', ''):


### PR DESCRIPTION
- The previous method was creating lists inside the dictionary values such as:

```{'__bigquerySource': [u'Library: bla'],
 '__qid': [u'9297b2910ea5d9f2fff6fcb042d4edbc'],
 'fl': u'title,abstract,comment,bibcode,author,keyword,id,citation_count,[citations],pub,aff,volume,pubdate,doi,pub_raw,page,links_data,property',
 'fq': [u'{!bitset}'],
 'hl': [u'true'],
 'hl.fl': [u'title,abstract,body,ack'],
 'hl.maxAnalyzedChars': [u'150000'],
 'hl.q': [u'*:*'],
 'hl.requireFieldMatch': [u'true'],
 'hl.usePhraseHighlighter': [u'true'],
 'q': [u'*:*'],
 'rows': [u'25'],
 'sort': [u'date desc, bibcode desc'],
 'start': [u'0'],
 'wt': 'json'}
```

And solr was not correctly interpreting the rows parameter, returning as many results as bibcodes were provided in the request data.