### PR TITLE
Correctly build solr request parameters avoiding lists for rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *pyc
 .idea
+python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: python
+
 python:
   - "2.7"
+
 install:
-  - pip install --upgrade pip
-  - pip install -r requirements.txt
-  - pip install -r dev-requirements.txt
+  - "pip install -r requirements.txt"
+  - "pip install -r dev-requirements.txt"
+
 script:
-  - py.test
+  - "py.test"
+
 after_success:
   - "coveralls"
+
+notifications:
+  email: false
+
 sudo: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/adsabs/ADSMicroserviceUtils.git@master
+git+https://github.com/adsabs/ADSMicroserviceUtils.git@v1.0.3
 Werkzeug==0.10.4
 Flask==0.10.1
 Flask-RESTful==0.3.5
@@ -7,5 +7,5 @@ flask-discoverer==0.0.2
 flask-consulate==0.1.2
 Flask-SQLAlchemy==2.1
 SQLAlchemy-Utils==0.27.7
-psycopg2==2.6.1
+psycopg2==2.7.3.2
 alembic==0.8.1

--- a/solr/tests/unittests/test_solr.py
+++ b/solr/tests/unittests/test_solr.py
@@ -41,6 +41,41 @@ class TestSolrInterface(TestCase):
         Simple test of the cleanup classmethod
         """
         si = SolrInterface()
+        payload = {}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
+        self.assertEqual(cleaned['fl'], 'id')
+
+        payload = {'rows': '1000000'}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
+
+        payload = {'rows': 1000000}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
+
+        payload = {'rows': '5'}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], 5)
+
+        payload = {'rows': ['5', '1000000']}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], 5)
+
+        payload = {'rows': ['1', '0']}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['rows'], 1)
+
+        payload = {'hl.snippets': 1000000, 'hl.fragsize': 1000000}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['hl.snippets'], self.app.config.get('SOLR_SERVICE_MAX_SNIPPETS', 4))
+        self.assertEqual(cleaned['hl.fragsize'], self.app.config.get('SOLR_SERVICE_MAX_FRAGSIZE', 100))
+
+        payload = {'hl.snippets': [2, 1000000], 'hl.fragsize': [3, 1000000]}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['hl.snippets'], self.app.config.get('SOLR_SERVICE_MAX_SNIPPETS', 2))
+        self.assertEqual(cleaned['hl.fragsize'], self.app.config.get('SOLR_SERVICE_MAX_FRAGSIZE', 3))
+
         payload = {'fl': ['id,bibcode,title,volume']}
         cleaned = si.cleanup_solr_request(payload)
         self.assertEqual(cleaned['fl'], 'id,bibcode,title,volume')
@@ -48,6 +83,7 @@ class TestSolrInterface(TestCase):
         payload = {'fl': ['id ', ' bibcode ', 'title ', ' volume']}
         cleaned = si.cleanup_solr_request(payload)
         self.assertEqual(cleaned['fl'], 'id,bibcode,title,volume')
+        self.assertEqual(cleaned['rows'], self.app.config.get('SOLR_SERVICE_MAX_ROWS', 100))
 
         payload = {'fl': ['id', 'bibcode', '*']}
         cleaned = si.cleanup_solr_request(payload)
@@ -56,6 +92,10 @@ class TestSolrInterface(TestCase):
         payload = {'fl': ['id,bibcode,*']}
         cleaned = si.cleanup_solr_request(payload)
         self.assertNotIn('*', cleaned['fl'])
+
+        payload = {'fq': ['pos(1,author:foo)']}
+        cleaned = si.cleanup_solr_request(payload)
+        self.assertEqual(cleaned['fq'], ['pos(1,author:foo)'])
 
 
     def test_limits(self):


### PR DESCRIPTION
- The previous method was creating lists inside the dictionary values such as:

```
{'__bigquerySource': [u'Library: bla'],
 '__qid': [u'9297b2910ea5d9f2fff6fcb042d4edbc'],
 'fl': u'title,abstract,comment,bibcode,author,keyword,id,citation_count,[citations],pub,aff,volume,pubdate,doi,pub_raw,page,links_data,property',
 'fq': [u'{!bitset}'],
 'hl': [u'true'],
 'hl.fl': [u'title,abstract,body,ack'],
 'hl.maxAnalyzedChars': [u'150000'],
 'hl.q': [u'*:*'],
 'hl.requireFieldMatch': [u'true'],
 'hl.usePhraseHighlighter': [u'true'],
 'q': [u'*:*'],
 'rows': [u'25'],
 'sort': [u'date desc, bibcode desc'],
 'start': [u'0'],
 'wt': 'json'}
```

And solr was not correctly interpreting the rows parameter, returning as many results as bibcodes were provided in the request data.