### PR TITLE
Docs operator fixes

### DIFF
--- a/solr/tests/unittests/test_solr.py
+++ b/solr/tests/unittests/test_solr.py
@@ -324,7 +324,7 @@ class TestWebservices(TestCase):
             assert x[2] == 'big-query/csv'
         
         data = {
-            'query': json.dumps({'query': {'hHGU1Ef-TpacAhicI3J8kQ': 'foo bar'}, 
+            'query': json.dumps({'query': 'q=foo&hHGU1Ef-TpacAhicI3J8kQ=foo+bar', 
                                'bigquery': 'something'})
         }
         with mock.patch.object(self.app.client, 'get', return_value=din) as get, \
@@ -341,7 +341,7 @@ class TestWebservices(TestCase):
             
 
         data = {
-            'query': json.dumps({'query': {'hHGU1Ef-TpacAhicI3J8kQ': 'foo bar'}, 
+            'query': json.dumps({'query': 'q=foo&hHGU1Ef-TpacAhicI3J8kQ=foo+bar',
                                  'bigquery': 'something'})
         }
         with mock.patch.object(self.app.client, 'get', return_value=din) as get, \

--- a/solr/tests/unittests/test_solr.py
+++ b/solr/tests/unittests/test_solr.py
@@ -324,8 +324,8 @@ class TestWebservices(TestCase):
             assert x[2] == 'big-query/csv'
         
         data = {
-            'query': { },
-            'bigquery': 'something'
+            'query': json.dumps({'query': {'hHGU1Ef-TpacAhicI3J8kQ': 'foo bar'}, 
+                               'bigquery': 'something'})
         }
         with mock.patch.object(self.app.client, 'get', return_value=din) as get, \
             mock.patch('solr.views.requests.post', return_value=out) as post:
@@ -339,10 +339,10 @@ class TestWebservices(TestCase):
             x = post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ']
             assert x[2] == 'big-query/csv'
             
-        
+
         data = {
-            'query': { 'hHGU1Ef-TpacAhicI3J8kQ': 'foo bar' },
-            'bigquery': 'something'
+            'query': json.dumps({'query': {'hHGU1Ef-TpacAhicI3J8kQ': 'foo bar'}, 
+                                 'bigquery': 'something'})
         }
         with mock.patch.object(self.app.client, 'get', return_value=din) as get, \
             mock.patch('solr.views.requests.post', return_value=out) as post:

--- a/solr/tests/unittests/test_solr.py
+++ b/solr/tests/unittests/test_solr.py
@@ -406,6 +406,7 @@ class TestWebservices(TestCase):
             assert get.called == False
             assert post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ'][1] == 'hey joe'
             assert post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ'][2] == 'big-query/csv'
+            assert '/solr/bigquery' in post.call_args[0][0]
             
                 
     

--- a/solr/tests/unittests/test_solr.py
+++ b/solr/tests/unittests/test_solr.py
@@ -321,7 +321,6 @@ class TestWebservices(TestCase):
             assert '/biblib/libraries/hHGU1Ef-TpacAhicI3J8kQ' in get.call_args[0][0]
             '/solr/bigquery' in post.call_args[0]
             x = post.call_args[1]['files']['library/hHGU1Ef-TpacAhicI3J8kQ']
-            assert x[1].closed == True
             assert x[2] == 'big-query/csv'
         
         data = {
@@ -338,7 +337,6 @@ class TestWebservices(TestCase):
             assert '/vault/query/hHGU1Ef-TpacAhicI3J8kQ' in get.call_args[0][0]
             '/solr/bigquery' in post.call_args[0]
             x = post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ']
-            assert x[1].closed == True
             assert x[2] == 'big-query/csv'
             
         
@@ -357,7 +355,6 @@ class TestWebservices(TestCase):
             '/solr/bigquery' in post.call_args[0]
             
             x = post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ']
-            assert x[1].closed == True
             assert x[2] == 'big-query/csv'
             
         
@@ -369,7 +366,7 @@ class TestWebservices(TestCase):
                                  data={
                                      'q': '*:*',
                                      'fq': 'docs(hHGU1Ef-TpacAhicI3J8kQ)',
-                                     'big': (StringIO('foo\nbar'), 'big-query/csv')
+                                     'big': (StringIO('foo\nbar'), 'bigname', 'big-query/csv')
                                      },
                                  headers={'Authorization': 'Bearer foo'})
             # it made a request to retrieve library
@@ -377,12 +374,40 @@ class TestWebservices(TestCase):
             assert '/vault/query/hHGU1Ef-TpacAhicI3J8kQ' in get.call_args[0][0]
             '/solr/bigquery' in post.call_args[0]
             
-            x = post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ']
-            assert x[1].closed == True
-            assert x[2] == 'big-query/csv'
+            assert post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ'][1] == 'foo bar'
+            assert post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ'][2] == 'big-query/csv'
             
-            assert 'big' in post.call_args[1]['files']
+            assert post.call_args[1]['files']['big'][1].closed == True
+            assert post.call_args[1]['files']['big'][2] == 'big-query/csv'
+            
         
+        # and also allowed for GET requests
+        with mock.patch.object(self.app.client, 'get', return_value=din) as get, \
+            mock.patch('solr.views.requests.post', return_value=out) as post:
+            r = self.client.get(url_for('search'), 
+                                 query_string={'q': 'docs(hHGU1Ef-TpacAhicI3J8kQ)'},
+                                 headers={'Authorization': 'Bearer foo'})
+            # it made a request to retrieve library
+            get.assert_called()
+            assert '/vault/query/hHGU1Ef-TpacAhicI3J8kQ' in get.call_args[0][0]
+            '/solr/bigquery' in post.call_args[0]
+            
+            assert post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ'][1] == 'foo bar'
+            assert post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ'][2] == 'big-query/csv'
+            
+        # GET request with data in params
+        with mock.patch.object(self.app.client, 'get', return_value=din) as get, \
+            mock.patch('solr.views.requests.post', return_value=out) as post:
+            r = self.client.get(url_for('search'), 
+                                 query_string={'q': 'docs(hHGU1Ef-TpacAhicI3J8kQ)', 
+                                               'hHGU1Ef-TpacAhicI3J8kQ': 'hey joe'},
+                                 headers={'Authorization': 'Bearer foo'})
+            # it made no request to retrieve library
+            assert get.called == False
+            assert post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ'][1] == 'hey joe'
+            assert post.call_args[1]['files']['hHGU1Ef-TpacAhicI3J8kQ'][2] == 'big-query/csv'
+            
+                
     
     def test_search(self):
         """
@@ -391,6 +416,7 @@ class TestWebservices(TestCase):
         with MockSolrResponse(self.app.config['SOLR_SERVICE_SEARCH_HANDLER']):
             r = self.client.get(url_for('search'))
             self.assertIn('responseHeader', r.json)
+            
 
     @httpretty.activate
     def test_qtree(self):
@@ -490,7 +516,7 @@ class TestWebservices(TestCase):
                     'q': '*:*',
                     'fl': 'bibcode',
                     'fq': '{!bitset}',
-                    'file_field': (StringIO(bibcodes), 'big-query/csv')
+                    'file_field': (StringIO(bibcodes), 'file', 'big-query/csv')
                 }
         )
 
@@ -503,7 +529,7 @@ class TestWebservices(TestCase):
                 data={
                     'q': '*:*',
                     'fl': 'bibcode',
-                    'file_field': (StringIO(bibcodes), 'big-query/csv'),
+                    'file_field': (StringIO(bibcodes), 'filename', 'big-query/csv'),
                     }
         )
 
@@ -518,7 +544,7 @@ class TestWebservices(TestCase):
                     'q': '*:*',
                     'fl': 'bibcode',
                     'fq': '{compression = true}',
-                    'file_field': (StringIO(bibcodes), 'big-query/csv'),
+                    'file_field': (StringIO(bibcodes), 'filename', 'big-query/csv'),
                     }
         )
 
@@ -531,8 +557,8 @@ class TestWebservices(TestCase):
             ('q', '*:*'),
             ('fl', 'bibcode'),
             ('fq', '{!bitset}'),
-            ('file_field', (StringIO(bibcodes), 'big-query/csv')),
-            ('file_field', (StringIO(bibcodes), 'big-query/csv')),
+            ('file_field', (StringIO(bibcodes), 'filename', 'big-query/csv')),
+            ('file_field', (StringIO(bibcodes), 'filename', 'big-query/csv')),
         ])
 
         resp = self.client.post(

--- a/solr/views.py
+++ b/solr/views.py
@@ -312,11 +312,11 @@ class SolrInterface(Resource):
                 r = current_app.client.get(current_app.config['VAULT_ENDPOINT'] + '/' + value,
                                            headers=new_headers)
                 r.raise_for_status()
-                q = r.json()
+                q = json.loads(r.json()['query'])
                 if value in q['query']: # it is incoded in parameters
                     docs = q['query'][value]
-                elif q['bigquery']: # this query has a bigquery, so it must be that
-                    docs = q['bigquery']
+                elif 'bigquery' in q['query'] and q['query']['bigquery']: # this query has a bigquery, so it must be that
+                    docs = q['query']['bigquery']
                 else: 
                     raise Exception('Query relies on {} however such queryid is not available via API'.format(s))
             

--- a/solr/views.py
+++ b/solr/views.py
@@ -49,9 +49,9 @@ class SolrInterface(Resource):
         files = self.check_for_embedded_bigquery(query, request, headers)
 
         current_app.logger.info("Dispatching 'POST' request to endpoint '{}'".format(current_app.config[self.handler]))
-        if files and len(files):
+        if files and len(files): # must be directed to /bigquery
             r = requests.post(
-                current_app.config[self.handler],
+                current_app.config['SOLR_SERVICE_BIGQUERY_HANDLER'],
                 params=query,
                 headers=headers,
                 files=files,


### PR DESCRIPTION
I tried to maintain backwards compatibility, the difficulty here is that old code was trying to simplify life of api users - but it was doing it incorrectly - by setting global headers (Cotnent-Type) and also by adding `fq` parameter for bigquery when it was missing.

I have tried to keep this functionality in existence, but also tried to sanitize the flow - we are sending files whenever there is bigquery or when docs() operator is used

request.data in bigquery is probably never used, but i kept it there becuase i'm not sure