### PR TITLE
Added option to send bot traffic to a different backend

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,7 +24,11 @@ SOLR_SERVICE_ALLOWED_FIELDS = [
     'property', 'pub', 'pubdate', 'read_count', 'title', 'vizier', 'volume',
     'year'
 ]
+BOT_SOLR_SERVICE_URL = os.environ.get('BOT_SOLR_SERVICE_URL', SOLR_SERVICE_URL)
+BOT_SOLR_SERVICE_SEARCH_HANDLER = BOT_SOLR_SERVICE_URL + '/select'
+BOT_SOLR_SERVICE_BIGQUERY_HANDLER = BOT_SOLR_SERVICE_URL + '/bigquery'
+BOT_TOKENS = []
 
 API_URL = 'http://adsws'
-VAULT_ENDPOINT = API_URL + '/vault/query' 
+VAULT_ENDPOINT = API_URL + '/vault/query'
 LIBRARY_ENDPOINT = API_URL + '/biblib/libraries'

--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ SOLR_SERVICE_QTREE_HANDLER = SOLR_SERVICE_URL + '/qtree'
 SOLR_SERVICE_BIGQUERY_HANDLER = SOLR_SERVICE_URL + '/bigquery'
 SOLR_SERVICE_FORWARDED_COOKIES = set(['sroute'])
 SOLR_SERVICE_DISALLOWED_FIELDS = ['body', 'full', 'reader']
+SOLR_SERVICE_ALLOWED_FACET_FIELDS = ['bibstem_facet', 'author_facet_hier', 'property', 'keyword_facet', 'year', 'bibgroup_facet', 'data_facet', 'vizier_facet', 'grant_facet_hier', 'database', 'simbad_object_facet_hier', 'aff_facet_hier', 'doctype_facet_hier', 'first_author_facet_hier', 'ned_object_facet_hier',]
 SOLR_SERVICE_MAX_ROWS = 2000
 SOLR_SERVICE_DEFAULT_ROWS = 10
 SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/adsabs/ADSMicroserviceUtils.git@v1.1.4
 alembic==0.8.1
+Werkzeug==0.16.1

--- a/solr/views.py
+++ b/solr/views.py
@@ -32,7 +32,7 @@ class StatusView(Resource):
 
 class SolrInterface(Resource):
     """Base class that responsible for forwarding a query to Solr"""
-    handler = {'default': 'SOLR_SERVICE_URL', 'embedded_bigquery': 'SOLR_SERVICE_BIGQUERY_HANDLER'}
+    handler = {'default': 'SOLR_SERVICE_URL', 'default_embedded_bigquery': 'SOLR_SERVICE_BIGQUERY_HANDLER'}
 
     def __init__(self, *args, **kwargs):
         Resource.__init__(self, *args, **kwargs)
@@ -63,7 +63,7 @@ class SolrInterface(Resource):
         handler_class = self.get_handler_class()
         files = self.check_for_embedded_bigquery(query, request, headers, handler_class=handler_class)
         if files and len(files): # must be directed to /bigquery
-            handler_class = 'embedded_bigquery'
+            handler_class += '_embedded_bigquery'
         handler = self.handler.get(handler_class, self.handler.get("default"))
 
         try:
@@ -492,8 +492,9 @@ class Search(SolrInterface):
     rate_limit = [5000, 60*60*24]
     decorators = [advertise('scopes', 'rate_limit')]
     handler = {'default': 'SOLR_SERVICE_SEARCH_HANDLER',
-               'embedded_bigquery': 'SOLR_SERVICE_BIGQUERY_HANDLER',
-               'bot': 'BOT_SOLR_SERVICE_SEARCH_HANDLER'}
+               'default_embedded_bigquery': 'SOLR_SERVICE_BIGQUERY_HANDLER',
+               'bot': 'BOT_SOLR_SERVICE_SEARCH_HANDLER',
+               'bot_embedded_bigquery': 'BOT_SOLR_SERVICE_BIGQUERY_HANDLER'}
 
     def get_handler_class(self):
         """Identify bot requests based on their authentication token"""
@@ -520,8 +521,9 @@ class BigQuery(SolrInterface):
     rate_limit = [100, 60*60*24]
     decorators = [advertise('scopes', 'rate_limit')]
     handler = {'default': 'SOLR_SERVICE_BIGQUERY_HANDLER',
-               'embedded_bigquery': 'SOLR_SERVICE_BIGQUERY_HANDLER',
-               'bot': 'BOT_SOLR_SERVICE_BIGQUERY_HANDLER'}
+               'default_embedded_bigquery': 'SOLR_SERVICE_BIGQUERY_HANDLER',
+               'bot': 'BOT_SOLR_SERVICE_BIGQUERY_HANDLER',
+               'bot_embedded_bigquery': 'BOT_SOLR_SERVICE_BIGQUERY_HANDLER'}
 
     def get_handler_class(self):
         """Identify bot requests based on their authentication token"""

--- a/solr/views.py
+++ b/solr/views.py
@@ -9,7 +9,7 @@ except:
 import json
 from models import Limits
 from sqlalchemy import or_
-from werkzeug import MultiDict
+from werkzeug.datastructures import MultiDict
 try:
     from cStringIO import StringIO
 except:

--- a/solr/views.py
+++ b/solr/views.py
@@ -226,9 +226,31 @@ class SolrInterface(Resource):
                 self._cleanup_fl(payload, user_id, k)
             if k == 'rows' or '.rows' in k:
                 self._cleanup_rows(payload, user_id, k)
+            if k == 'facet.field':
+                self._cleanup_facet_fields(payload, k)
 
         return payload, headers
 
+    def _cleanup_facet_fields(self, payload, key):
+        """
+        Only allow facet fields for which solr has warmed up, otherwise the
+        request might lock the solr instance for several minutes.
+
+        See: https://github.com/romanchyla/montysolr/blob/f731739cb83a14d1373e680bc955c2f04ff6db92/contrib/examples/adsabs/server/solr/collection1/conf/solrconfig.xml#L180
+        """
+        values = payload[key]
+        if not isinstance(values, list):
+            values = [values]
+
+        facet_fields = []
+        for y in values:
+            facet_fields.extend([i.strip().lower() for i in y.split(',')])
+
+        allowed_facet_fields = current_app.config.get('SOLR_SERVICE_ALLOWED_FACET_FIELDS')
+        if allowed_facet_fields:
+            facet_fields = filter(lambda x: x in allowed_facet_fields, facet_fields)
+
+        payload[key] = ','.join(facet_fields)
 
     def _cleanup_rows(self, payload, user_id, key):
         """Ensure rows does not bypass the max rows limit"""

--- a/solr/views.py
+++ b/solr/views.py
@@ -399,6 +399,8 @@ class SolrInterface(Resource):
                 value = s
 
             new_headers = {'Authorization': request.headers['Authorization']}
+            if 'X-Forwarded-Authorization' in request.headers:
+                new_headers['X-Forwarded-Authorization'] = request.headers['X-Forwarded-Authorization']
             # trace id, Host, token header are important for proper routing/logging
             handler = self.handler.get(handler_class, self.handler.get("default", "-"))
             new_headers['Host'] = self.get_host(current_app.config.get(handler))

--- a/solr/views.py
+++ b/solr/views.py
@@ -496,7 +496,11 @@ class Search(SolrInterface):
                'bot': 'BOT_SOLR_SERVICE_SEARCH_HANDLER'}
 
     def get_handler_class(self):
-        request_token = request.headers.get('Authorization', [])[7:]
+        """Identify bot requests based on their authentication token"""
+        if 'X-Forwarded-Authorization' in request.headers:
+            request_token = request.headers.get('X-Forwarded-Authorization', [])[7:]
+        else:
+            request_token = request.headers.get('Authorization', [])[7:]
         if request_token in current_app.config.get('BOT_TOKENS', []):
             return "bot"
         else:
@@ -520,7 +524,11 @@ class BigQuery(SolrInterface):
                'bot': 'BOT_SOLR_SERVICE_BIGQUERY_HANDLER'}
 
     def get_handler_class(self):
-        request_token = request.headers.get('Authorization', [])[7:]
+        """Identify bot requests based on their authentication token"""
+        if 'X-Forwarded-Authorization' in request.headers:
+            request_token = request.headers.get('X-Forwarded-Authorization', [])[7:]
+        else:
+            request_token = request.headers.get('Authorization', [])[7:]
         if request_token in current_app.config.get('BOT_TOKENS', []):
             return "bot"
         else:


### PR DESCRIPTION
Requests with a token listed in `BOT_TOKENS` will be sent to `BOT_SOLR_SERVICE_SEARCH_HANDLER` instead of `SOLR_SERVICE_SEARCH_HANDLER`. This option can be disabled by leaving an empty `BOT_TOKENS` or using the same values for `BOT_SOLR_SERVICE_SEARCH_HANDLER` and `SOLR_SERVICE_SEARCH_HANDLER`.
