### PR TITLE
Prevent duplicate windowed highlights

### DIFF
--- a/solr/views.py
+++ b/solr/views.py
@@ -202,15 +202,49 @@ class SolrInterface(Resource):
 
     def apply_highlight_window(self, highlight_text: str, max_len: int) -> List[str]:
         highlight_pattern = re.compile(r'<em>[^>]*</em>', re.IGNORECASE)
-        windowed_snippets = []
 
-        for match in re.finditer(highlight_pattern, highlight_text):
-            start, end = match.span()
-            if end - start >= max_len:
+        matches = list(re.finditer(highlight_pattern, highlight_text))
+        if not matches:
+            return []
+
+        # Greedily group consecutive matches that fit within a single max_len window
+        groups = []
+        current_group = [matches[0]]
+        for match in matches[1:]:
+            if match.end() - current_group[0].start() <= max_len:
+                current_group.append(match)
+            else:
+                groups.append(current_group)
+                current_group = [match]
+        groups.append(current_group)
+
+        windowed_snippets = []
+        text_len = len(highlight_text)
+
+        for group in groups:
+            group_start = group[0].start()
+            group_end = group[-1].end()
+            extent = group_end - group_start
+
+            if extent > max_len:
                 continue
 
-            diff = (max_len - (end - start))//2
-            windowed_snippets.append(highlight_text[max(0, start-diff):end+diff-min(0, start-diff)])
+            remaining = max_len - extent
+            pad_before = remaining // 2
+            pad_after = remaining - pad_before
+
+            win_start = group_start - pad_before
+            win_end = group_end + pad_after
+
+            # Redistribute unused padding at text boundaries
+            if win_start < 0:
+                win_end = min(text_len, win_end - win_start)
+                win_start = 0
+            if win_end > text_len:
+                win_start = max(0, win_start - (win_end - text_len))
+                win_end = text_len
+
+            windowed_snippets.append(highlight_text[win_start:win_end])
 
         return windowed_snippets
 


### PR DESCRIPTION
# Why?

The previous, naive windowed highlights algorithm could produce multiple output windows containing the same highlighted phrase. For highlights below the maximum length containing multiple highlighted phrases, this results in duplicate output windows. Duplicate highlights are confusing for users and should not be present in API outputs.

# What?

Replaces the naive algorithm with a greedy one. The new algorithm attempts to pack as many spans as possible into a single window while staying below the maximum length.