### PR TITLE
Solr Allocation Logging

### DIFF
--- a/alembic/versions/59ce6fb5526_create_query_logging_table.py
+++ b/alembic/versions/59ce6fb5526_create_query_logging_table.py
@@ -1,0 +1,31 @@
+"""Create query logging table
+
+Revision ID: 59ce6fb5526
+Revises: 51f3b3b5cd5d
+Create Date: 2026-05-22 15:22:17.468189
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '59ce6fb5526'
+down_revision = '51f3b3b5cd5d'
+
+from alembic import op
+import sqlalchemy as sa
+
+import datetime
+
+from sqlalchemy.sql import table, column
+from sqlalchemy import String, Integer, Index
+
+
+def upgrade():
+    op.create_table('query_log',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('query', sa.Text, nullable=False),
+        sa.Column('allocated_bytes', sa.Integer, nullable=False),
+        sa.Column('request_duration', sa.Integer, nullable=False)
+    )
+
+def downgrade():
+    op.drop_table('query_log')

--- a/alembic/versions/59ce6fb5526_create_query_logging_table.py
+++ b/alembic/versions/59ce6fb5526_create_query_logging_table.py
@@ -22,6 +22,7 @@ from sqlalchemy import String, Integer, Index
 def upgrade():
     op.create_table('query_log',
         sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('timestamp', sa.Integer, nullable=False),
         sa.Column('query', sa.Text, nullable=False),
         sa.Column('allocated_bytes', sa.Integer, nullable=False),
         sa.Column('request_duration', sa.Integer, nullable=False)

--- a/alembic/versions/59ce6fb5526_create_query_logging_table.py
+++ b/alembic/versions/59ce6fb5526_create_query_logging_table.py
@@ -22,10 +22,10 @@ from sqlalchemy import String, Integer, Index
 def upgrade():
     op.create_table('query_log',
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('timestamp', sa.Integer, nullable=False),
+        sa.Column('timestamp', sa.DateTime, nullable=False),
         sa.Column('query', sa.Text, nullable=False),
         sa.Column('allocated_bytes', sa.Integer, nullable=False),
-        sa.Column('request_duration', sa.Integer, nullable=False)
+        sa.Column('request_duration', sa.Interval, nullable=False)
     )
 
 def downgrade():

--- a/solr/models.py
+++ b/solr/models.py
@@ -5,7 +5,7 @@
 
     Models for the users (users) of AdsWS
 """
-from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy import Column, Integer, String, Text, DateTime, Interval
 from sqlalchemy.ext.declarative import declarative_base
 
 
@@ -30,7 +30,7 @@ class Limits(Base):
 class QueryLog(Base):
     __tablename__ = 'query_log'
     id = Column(Integer, primary_key=True)
-    timestamp = Column("timestamp", Integer, nullable=False)
+    timestamp = Column("timestamp", DateTime, nullable=False)
     query = Column("query", Text, nullable=False)
     allocated_bytes = Column("allocated_bytes", Integer, nullable=False)
-    request_duration = Column("request_duration", Integer, nullable=False)
+    request_duration = Column("request_duration", Interval, nullable=False)

--- a/solr/models.py
+++ b/solr/models.py
@@ -26,3 +26,11 @@ class Limits(Base):
             'field': self.field,
             'filter': self.filter or None
         }
+
+class QueryLog(Base):
+    __tablename__ = 'query_log'
+    id = Column(Integer, primary_key=True)
+    timestamp = Column("timestamp", Integer, nullable=False)
+    query = Column("query", Text, nullable=False)
+    allocated_bytes = Column("allocated_bytes", Integer, nullable=False)
+    request_duration = Column("request_duration", Integer, nullable=False)

--- a/solr/views.py
+++ b/solr/views.py
@@ -108,7 +108,7 @@ class SolrInterface(Resource):
 
                 return json.dumps(response_data), r.status_code, r.headers
             except Exception as e:
-                current_app.logger.error(e.with_traceback())
+                current_app.logger.error(e)
 
         return r.text, r.status_code, r.headers
 

--- a/solr/views.py
+++ b/solr/views.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import datetime
 import re
 
 from future import standard_library
@@ -15,7 +16,7 @@ except ImportError:
     # If solr service is not shipped with adsws, this will fail and it is ok
     pass
 import json
-from .models import Limits
+from .models import Limits, QueryLog
 from sqlalchemy import or_
 from werkzeug.datastructures import MultiDict
 from io import StringIO
@@ -81,6 +82,7 @@ class SolrInterface(Resource):
 
         current_app.logger.info("Dispatching 'POST' request to endpoint '{}' for user '{}'".format(current_app.config[self.handler[handler_class]], current_user_id or "anonymous"))
 
+        start_time = datetime.datetime.now(datetime.timezone.utc)
         if files and len(files): # must be directed to /bigquery
             r = requests.post(
                 current_app.config[handler],
@@ -96,12 +98,13 @@ class SolrInterface(Resource):
                 headers=headers,
                 cookies=SolrInterface.set_cookies(request),
             )
+        end_time = datetime.datetime.now(datetime.timezone.utc)
         current_app.logger.info("Received response from from endpoint '{}' with status code '{}'".format(current_app.config[handler], r.status_code))
 
         # Run this if we've identified a need to alter the response from Solr
         if should_postprocess_response and r.ok:
             try:
-                response_data = self.postprocess_response(r)
+                response_data = self.postprocess_response(r, start_time, end_time)
 
                 return json.dumps(response_data), r.status_code, r.headers
             except Exception as e:
@@ -152,7 +155,7 @@ class SolrInterface(Resource):
 
         return should_postprocess_response
 
-    def postprocess_response(self, r: requests.Response) -> dict:
+    def postprocess_response(self, r: requests.Response, start_time: datetime.datetime, end_time: datetime.datetime) -> dict:
         response_data = r.json()
         unhighlightable_publishers = current_app.config.get('SOLR_SERVICE_DISALLOWED_HIGHLIGHTS_PUBLISHERS', [])
         unhighlightable_docs = []
@@ -202,6 +205,14 @@ class SolrInterface(Resource):
             query = response_data.get('responseHeader', {}).get('params', {}).get('q')
             if query:
                 current_app.logger.info(f"Query: {query}, Allocated Bytes: {response_data['allocatedBytes']}")
+                with current_app.session_scope() as session:
+                    session.add(QueryLog(
+                        timestamp=start_time,
+                        query=query,
+                        allocated_bytes=response_data['allocatedBytes'],
+                        request_duration=end_time - start_time
+                    ))
+                    session.commit()
 
         response_data['filtered'] = 'true'
 

--- a/solr/views.py
+++ b/solr/views.py
@@ -70,7 +70,8 @@ class SolrInterface(Resource):
             handler_class += '_embedded_bigquery'
         handler = self.handler.get(handler_class, self.handler.get("default"))
 
-        should_postprocess_response = self.preprocess_request(handler, query)
+        should_postprocess_response = True
+        self.preprocess_request(handler, query)
 
         try:
             current_user_id = current_user.get_id()

--- a/solr/views.py
+++ b/solr/views.py
@@ -178,24 +178,25 @@ class SolrInterface(Resource):
                     if remove_key in doc_highlights:
                         del doc_highlights[remove_key]
 
-        max_frag = current_app.config.get('SOLR_SERVICE_MAX_FRAGSIZE', 200)
-        for doc_id in list(response_data['highlighting'].keys()):
-            current_highlights = response_data['highlighting'][doc_id]
-            new_highlights = dict()
+        if 'highlighting' in response_data:
+            max_frag = current_app.config.get('SOLR_SERVICE_MAX_FRAGSIZE', 200)
+            for doc_id in list(response_data['highlighting'].keys()):
+                current_highlights = response_data['highlighting'][doc_id]
+                new_highlights = dict()
 
-            for field in current_highlights.keys():
-                new_highlights[field] = [
-                    windowed_highlight
-                    for highlight in current_highlights[field]
-                    for windowed_highlight in self.apply_highlight_window(highlight, max_frag)
-                ]
+                for field in current_highlights.keys():
+                    new_highlights[field] = [
+                        windowed_highlight
+                        for highlight in current_highlights[field]
+                        for windowed_highlight in self.apply_highlight_window(highlight, max_frag)
+                    ]
 
-            response_data['highlighting'][doc_id] = new_highlights
-        
-        for _, doc_highlights in response_data['highlighting'].items():
-            for field, highlights in list(doc_highlights.items()):
-                doc_highlights[field] = [highlight for highlight in highlights
-                                         if highlight is not None and str(highlight).strip() != ""]
+                response_data['highlighting'][doc_id] = new_highlights
+
+            for _, doc_highlights in response_data['highlighting'].items():
+                for field, highlights in list(doc_highlights.items()):
+                    doc_highlights[field] = [highlight for highlight in highlights
+                                             if highlight is not None and str(highlight).strip() != ""]
 
         if 'allocatedBytes' in response_data:
             query = response_data.get('responseHeader', {}).get('params', {}).get('q')

--- a/solr/views.py
+++ b/solr/views.py
@@ -196,6 +196,11 @@ class SolrInterface(Resource):
                 doc_highlights[field] = [highlight for highlight in highlights
                                          if highlight is not None and str(highlight).strip() != ""]
 
+        if 'allocatedBytes' in response_data:
+            query = response_data.get('responseHeader', {}).get('params', {}).get('q')
+            if query:
+                current_app.logger.info(f"Query: {query}, Allocated Bytes: {response_data['allocatedBytes']}")
+
         response_data['filtered'] = 'true'
 
         return response_data

--- a/solr/views.py
+++ b/solr/views.py
@@ -378,7 +378,6 @@ class SolrInterface(Resource):
                     payload[k] = max(0, min(_safe_int(v, default=max_hl), max_hl))
                 elif '.fragsize' in k:
                     payload[k] = max(1, min(_safe_int(v, default=max_frag), max_frag)) #0 would return whole field
-                    payload['hl.maxHighlightCharacters'] = payload[k]
             if k == 'hl.fl':
                 self._cleanup_fields(payload, k, current_app.config.get('SOLR_SERVICE_ALLOWED_HIGHLIGHTS_FIELDS'))
             if k == 'fl' or ('.fl' in k and k != 'hl.fl'):


### PR DESCRIPTION
# What?

This PR adds logging for allocation data provided by Solr, both as a message and to a SQL table.

# Why?

As part of load balancing between multiple Solr instances, we need some way to robustly predict the cost of each query. Query time is only part of the equation, with some queries consuming 10-100x more memory than others and causing out-of-memory crashes on the searchers.

With this change we will start logging allocation and query time data. That data will eventually be used to create a model of query cost, which in turn will eventually be used to enforce rate limits for individual searchers.